### PR TITLE
Multiapps update

### DIFF
--- a/Extensions/2019/11-25-2019.md
+++ b/Extensions/2019/11-25-2019.md
@@ -28,6 +28,19 @@
 
 - new leadership from SAP is to be announced
 
+### [MultiApps](https://github.com/cloudfoundry-incubator/multiapps-cli-plugin)
+- adoption of CC v3 apis is close to completion, by adoption of [cf-java-client v4.1.0](https://github.com/cloudfoundry/cf-java-client/releases/tag/v4.1.0.RELEASE) 
+- finetunings of flowable engine & cf java client to sustain perofrmance at high load
+- Ongoing
+  * Utilizing CF metadata faster detection of deployed solution components
+  * Namespacing deployments so multiple instances can be deployed in a single space
+  * bg-deploy process leaving apps with their original names at the end
+- next in queue
+  * Rolling update strategy support
+  * Deploy time optimizations 
+- new entries in roadmap
+  * consumption of recent app logs from logcache instead of doppler or loggregator
+
 ## _Under Review_
 
 N/A
@@ -45,4 +58,4 @@ N/A
 
 ### [CF Abacus](https://github.com/cloudfoundry-incubator/cf-abacus)
 ### [Project Blockheads](https://github.com/cloudfoundry-incubator/blockhead)
-### [MultiApps](https://github.com/cloudfoundry-incubator/multiapps-cli-plugin)
+


### PR DESCRIPTION
Multiapps project update for activities done in Nov-Dec 2019
This PR removes the project as retired, where it las placed due to reporting inactivity